### PR TITLE
Add missing semicolon from mixin call.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -85,7 +85,7 @@
 			$custom-link-base: _oFooterServicesGet('default-link-color'),
 			$custom-link-hover: _oFooterServicesGet('default-link-hover'),
 			$custom-link-background: _oFooterServicesGet('default-background')
-		)
+		);
 
 		display: inline-block;
 		min-width: max-content;


### PR DESCRIPTION
dart-sass will not build with a missing semicolon, though lib-sass will.