### PR TITLE
Add a `oFooterServicesCustomize` mixin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,40 @@ Your project should call `oFooterServices` once, and add to the `opts` argument 
 ), $include-base-styles: false);
 ```
 
+### Customisation
+
+For users of the `whitelabel` brand, `o-footer-services` customise brand variables using the `oFooterServicesCustomize` mixin.
+
+```scss
+$o-brand: whitelabel;
+@import 'o-footer-services/main';
+
+// Customise o-footer-services colours
+@include oFooterServicesCustomize((
+	'text-color': rgb(73, 0, 39),
+	'background-color': rgb(251, 238, 240),
+	'border-color': hotpink,
+	'link-color': rgb(156, 4, 85),
+	'link-hover-color': rgb(156, 4, 85),
+	'legal-text-color': rgb(214, 73, 148)
+));
+
+// Output o-footer-services css
+@include oFooterServices($opts: (
+	'logo': 'ftlogo-v1:origami',
+	'icons': ()
+));
+```
+
+Available brand variables include:
+- `text-color`: The default text colour.
+- `background-color`: The default background colour.
+- `border-color`: The border colour used around and within the footer.
+- `link-color`: The default link colour.
+- `link-hover-color`: The default link colour when hovered.
+- `legal-text-color`: The colour of legal links within the footer. By design, this is also used for the legal link hover colour.
+
+
 ## Migration guide
 
 State | Major Version | Last Minor Release | Migration guide |

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ $o-brand: whitelabel;
 
 Available brand variables include:
 - `text-color`: The default text colour.
-- `background-color`: The default background colour.
+- `background-color`: The background colour.
 - `border-color`: The border colour used around and within the footer.
 - `link-color`: The default link colour.
-- `link-hover-color`: The default link colour when hovered.
-- `legal-text-color`: The colour of legal links within the footer. By design, this is also used for the legal link hover colour.
+- `link-hover-color`: The hover colour of links with no underline, i.e. icon links.
+- `legal-text-color`: The colour of legal links.
 
 
 ## Migration guide

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Your project should call `oFooterServices` once, and add to the `opts` argument 
 
 ### Customisation
 
-For users of the `whitelabel` brand, `o-footer-services` customise brand variables using the `oFooterServicesCustomize` mixin.
+For users of the `whitelabel` brand, `o-footer-services` allows customisation using the `oFooterServicesCustomize` mixin.
 
 ```scss
 $o-brand: whitelabel;

--- a/main.scss
+++ b/main.scss
@@ -39,11 +39,16 @@
 	@if($icons) {
 		.o-footer-services__icon-link {
 			@include oTypographySans($weight: 'semibold', $include-font-family: false);
-			@include _oFooterServicesLink(
-				$custom-link-base: _oFooterServicesGet('default-link-color'),
-				$custom-link-hover: _oFooterServicesGet('default-link-hover'),
-				$custom-link-background: _oFooterServicesGet('default-background')
-			);
+			@include oTypographyLink($theme: (
+				'base': _oFooterServicesGet('link-color'),
+				'hover': _oFooterServicesGet('link-hover-color'),
+				'context': _oFooterServicesGet('background-color')
+			));
+			// Remove link enderline.
+			border-bottom: 0;
+			@supports (text-decoration-thickness: 0.25ex) {
+				text-decoration-line: none;
+			}
 
 			display: inline-block;
 			min-width: max-content;

--- a/main.scss
+++ b/main.scss
@@ -44,7 +44,7 @@
 				'hover': _oFooterServicesGet('link-hover-color'),
 				'context': _oFooterServicesGet('background-color')
 			));
-			// Remove link enderline.
+			// Remove link underline.
 			border-bottom: 0;
 			@supports (text-decoration-thickness: 0.25ex) {
 				text-decoration-line: none;

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -10,29 +10,48 @@
 	@return oBrandSupportsVariant($component: 'o-footer-services', $variant: $variant);
 }
 
+/// Helper for `whitelabel` varibale customisation
+/// @brand whitelabel
+/// @param {Map} $variables - Brand variables to customise
+/// @access public
+/// @example scss
+///		@include oFooterServicesCustomize((
+///			'nav-background': hotpink;
+///			'nav-hover-background': candy;
+///		))
+@mixin oFooterServicesCustomize($variables) {
+	@include oBrandCustomize('o-footer-services', $variables);
+}
+
 $_o-footer-services-shared-brand-config: (
-	default-background: 'black-5',
-	default-border: 'black-20',
-	default-link-color: 'black-80',
-	default-link-hover: 'black-60',
-	legal-text: 'black-60',
-	legal-link-hover: 'black-80',
+	text-color: oColorsByName('black'),
+	background-color: oColorsByName('black-5'),
+	border-color: oColorsByName('black-20'),
+	link-color: oColorsByName('black-80'),
+	link-hover-color: oColorsByName('black-60'),
+	legal-text-color: oColorsByName('black-60')
 );
 
-@include oBrandDefine('o-footer-services', 'master', (
-	'variables': $_o-footer-services-shared-brand-config,
-	'supports-variants': ()
-));
+@if oBrandGetCurrentBrand() == 'master' {
+	@include oBrandDefine('o-footer-services', 'master', (
+		'variables': $_o-footer-services-shared-brand-config,
+		'supports-variants': ()
+	));
+}
 
-@include oBrandDefine('o-footer-services', 'internal', (
-	'variables': map-merge($_o-footer-services-shared-brand-config, (
-		'default-background': 'slate-white-5',
-		'default-border': 'slate-white-15',
-	)),
-	'supports-variants': ()
-));
+@if oBrandGetCurrentBrand() == 'internal' {
+	@include oBrandDefine('o-footer-services', 'internal', (
+		'variables': map-merge($_o-footer-services-shared-brand-config, (
+			'background-color': oColorsByName('slate-white-5'),
+			'border-color': oColorsByName('slate-white-15'),
+		)),
+		'supports-variants': ()
+	));
+}
 
-@include oBrandDefine('o-footer-services', 'whitelabel', (
-	'variables': $_o-footer-services-shared-brand-config,
-	'supports-variants': ()
-));
+@if oBrandGetCurrentBrand() == 'whitelabel' {
+	@include oBrandDefine('o-footer-services', 'whitelabel', (
+		'variables': $_o-footer-services-shared-brand-config,
+		'supports-variants': ()
+	));
+}

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -15,10 +15,14 @@
 /// @param {Map} $variables - Brand variables to customise
 /// @access public
 /// @example scss
-///		@include oFooterServicesCustomize((
-///			'nav-background': hotpink;
-///			'nav-hover-background': candy;
-///		))
+///     @include oFooterServicesCustomize((
+///     	'text-color': rgb(73, 0, 39),
+///     	'background-color': rgb(251, 238, 240),
+///     	'border-color': hotpink,
+///     	'link-color': rgb(156, 4, 85),
+///     	'link-hover-color': rgb(156, 4, 85),
+///     	'legal-text-color': rgb(214, 73, 148)
+///     ));
 @mixin oFooterServicesCustomize($variables) {
 	@include oBrandCustomize('o-footer-services', $variables);
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,7 +1,8 @@
 @mixin _oFooterServicesBase() {
 	.o-footer-services {
 		@include oTypographySans(0);
-		background: oColorsByName(_oFooterServicesGet('default-background'));
+		color: _oFooterServicesGet('text-color');
+		background: _oFooterServicesGet('background-color');
 	}
 
 	.o-footer-services__container {
@@ -11,7 +12,7 @@
 		&:before {
 			content: '';
 			position: absolute;
-			border-top: 1px solid oColorsByName(_oFooterServicesGet('default-border'));
+			border-top: 1px solid _oFooterServicesGet('border-color');
 			top: 0;
 			left: 0;
 			right: 0;
@@ -33,7 +34,7 @@
 
 		&--legal {
 			@include oTypographySans($scale: -1, $line-height: 20px);
-			color: oColorsByName(_oFooterServicesGet('legal-text'));
+			color: _oFooterServicesGet('legal-text-color');
 			overflow: hidden;
 
 			p {
@@ -52,12 +53,11 @@
 		margin: 0.5em 0;
 
 		a {
-			@include _oFooterServicesLink(
-				$custom-link-base: _oFooterServicesGet('legal-text'),
-				$custom-link-hover: _oFooterServicesGet('legal-text'),
-				$custom-link-background: _oFooterServicesGet('default-background'),
-				$link-hover: _oFooterServicesGet('legal-link-hover')
-			);
+			@include oTypographyLink($theme: (
+				'base': _oFooterServicesGet('legal-text-color'),
+				'hover': _oFooterServicesGet('legal-text-color'),
+				'context': _oFooterServicesGet('background-color')
+			));
 			margin-right: 0.5em;
 		}
 	}
@@ -66,20 +66,19 @@
 		margin: 0 0 1.5em;
 
 		a {
-			@include _oFooterServicesLink(
-				$custom-link-base: _oFooterServicesGet('default-link-color'),
-				$custom-link-hover: _oFooterServicesGet('default-link-color'),
-				$custom-link-background: _oFooterServicesGet('default-background'),
-				$link-hover: _oFooterServicesGet('default-link-hover')
-			);
+			@include oTypographyLink($theme: (
+				'base': _oFooterServicesGet('link-color'),
+				'hover': _oFooterServicesGet('link-hover-color'),
+				'context': _oFooterServicesGet('background-color')
+			));
 		}
 
 		.o-footer-services__content--external {
 			@include oTypographyLink(
 				$theme: (
-					'base': _oFooterServicesGet('default-link-color'),
-					'hover': _oFooterServicesGet('default-link-color'),
-					'context': _oFooterServicesGet('default-background')
+					'base': _oFooterServicesGet('link-color'),
+					'hover': _oFooterServicesGet('link-color'),
+					'context': _oFooterServicesGet('background-color')
 				),
 				$external: true,
 				$include-base-styles: false
@@ -146,25 +145,5 @@
 		vertical-align: middle;
 		top: -5px;
 		left: -5px;
-	}
-}
-
-@mixin _oFooterServicesLink($custom-link-base, $custom-link-hover, $custom-link-background, $link-hover: null) {
-	@include oTypographyLink($theme: (
-		'base': $custom-link-base,
-		'hover': $custom-link-hover,
-		'context': $custom-link-background
-	));
-
-	// Link underline is different by design.
-	@if $link-hover != null {
-		&:hover {
-			border-bottom-color: oColorsByName($link-hover);
-		}
-	} @else {
-		border-bottom: 0;
-		@supports (text-decoration-thickness: 0.25ex) {
-			text-decoration-line: none;
-		}
 	}
 }


### PR DESCRIPTION
So whitelabel brands may customise the colours of o-footer-services.

For example it's possible to set brand variables to pink colours -- I'm sure our
users will spend the time to come up with a much nicer design though :)
<img width="1227" alt="Screenshot 2020-06-10 at 15 10 45" src="https://user-images.githubusercontent.com/10405691/84279779-5a4c0c00-ab2e-11ea-8119-c883a788bdca.png">

**do not merge:** I was checking how straightforward it would be to allow
whitelabel customisation of `o-footer-services` and got a little carried away.
I would like to confirm the interface with the design team as well as Origami
before merging