### PR TITLE
Add a dark theme to o-footer-services.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ All options include:
 |-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|
 | logo      | A logo from the [image service](https://github.com/Financial-Times/origami-image-service.) to include in the footer (e.g. `ftlogo-v1:origami`).     | master, internal, whitelabel |
 | icons     | A list of [social share](https://registry.origami.ft.com/components/social-images) icons to include links for, defaults to '('slack', 'github')`.         | master, internal, whitelabel |
-| theme    | A list of themes to include. Currently the only theme is `dark`, which is only supported by the master brand.         | master |
+| themes    | A list of themes to include. Currently the only theme is `dark`, which is only supported by the master brand.         | master |
 
 
 Your project should call `oFooterServices` once, and add to the `opts` argument when new features are needed. However, if `oFooterServices` is called multiple times, for example for code splitting across multiple bundles, the `$include-base-styles` argument may be set to `false` to omit fundamental base styles required by all options.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # o-footer-services [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 
-o-footer-services is a footer component for internal products and tooling at the FT.
+o-footer-services is an [o-footer](https://registry.origami.ft.com/components/o-footer) alternative for tools, internal products, and specialist titles at the FT.
 
 - [Markup](#markup)
 - [Sass](#sass)
@@ -39,6 +39,17 @@ All elements within the `.o-footer-services__wrapper--top` section are entirely 
 
 As a move to future proof this component and the products that may use it, **`.o-footer-services__wrapper--legal` is not optional.**
 
+### Themes
+
+To use a dark theme, apply the `o-footer-services--dark` modifier class:
+
+```diff
+-<footer class="o-footer-services">
++<footer class="o-footer-services o-footer-services--dark">
+	<!-- ... -->
+</footer>
+```
+
 ## Sass
 
 To output all `o-footer-services` CSS call `oFooterServices()`.
@@ -48,12 +59,13 @@ To output all `o-footer-services` CSS call `oFooterServices()`.
 ```
 
 To keep your CSS bundle size small, include  `o-footer-services` features granularly using the `opts` argument.
-E.g. to output styles with a project logo but without the default icon link to Github:
+E.g. to output styles for the dark theme with a project logo, but without the default icon link to Github:
 
 ```scss
 @include oFooterServices($opts: (
 	'logo': 'ftlogo-v1:origami',
-	'icons': ('slack')
+	'icons': ('slack'),
+	'themes': ('dark'),
 ));
 ```
 All options include:
@@ -62,9 +74,10 @@ All options include:
 |-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|
 | logo      | A logo from the [image service](https://github.com/Financial-Times/origami-image-service.) to include in the footer (e.g. `ftlogo-v1:origami`).     | master, internal, whitelabel |
 | icons     | A list of [social share](https://registry.origami.ft.com/components/social-images) icons to include links for, defaults to '('slack', 'github')`.         | master, internal, whitelabel |
+| theme    | A list of themes to include. Currently the only theme is `dark`, which is only supported by the master brand.         | master |
 
 
-Your project should call `oFooterServices` once, and add to the `opts` argument when new features are needed. However, if `oFooterServices` is called multiple times, for example for code splitting across multiple bundles, the `$include-base-styles` argument may be set to `false` to ommit fundamental base styles required by all options.
+Your project should call `oFooterServices` once, and add to the `opts` argument when new features are needed. However, if `oFooterServices` is called multiple times, for example for code splitting across multiple bundles, the `$include-base-styles` argument may be set to `false` to omit fundamental base styles required by all options.
 ```scss
 // Output o-footer-services with no icons.
 @include oFooterServices($opts: (

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -10,5 +10,6 @@ body {
 
 @include oFooterServices($opts: (
 	'logo': 'ftlogo-v1:origami',
-	'icons': ('slack', 'github')
+	'icons': ('slack', 'github'),
+	'themes': ('dark')
 ));

--- a/demos/src/footer.mustache
+++ b/demos/src/footer.mustache
@@ -1,5 +1,5 @@
 <div class="demo">
-	<footer class="o-footer-services">
+	<footer class="o-footer-services{{#theme}} o-footer-services--{{theme}}{{/theme}}">
 		<div class="o-footer-services__container">
 			<div class="o-footer-services__wrapper o-footer-services__wrapper--top">
 				<p class="o-footer-services__logo">Origami</p>

--- a/main.scss
+++ b/main.scss
@@ -14,10 +14,12 @@
 /// @access public
 @mixin oFooterServices($opts: (
 	'logo': false,
-	'icons': ('slack', 'github')
+	'icons': ('slack', 'github'),
+	'themes': ('dark')
 ), $include-base-styles: true) {
 	$logo: map-get($opts, 'logo');
 	$icons: map-get($opts, 'icons');
+	$themes: map-get($opts, 'themes');
 
 	// Error if the global $system-code variable is not set.
 	// This is required for image service requests.
@@ -27,46 +29,56 @@
 
 	// Output fundamental o-footer-services styles required by all users.
 	@if($include-base-styles) {
-		@include _oFooterServicesBase();
+		.o-footer-services {
+			@include _oFooterServicesBase();
+			// include default theme with base styles
+			@include _oFooterServicesTheme($theme-name: null, $icons: $icons);
+		}
 	}
 
 	// Output classes for a logo in the footer.
 	@if($logo) {
-		@include _oFooterServicesLogo($logo);
+		.o-footer-services__logo {
+			@include _oFooterServicesLogo($logo);
+		}
 	}
 
 	// Output classes for footer icons.
 	@if($icons) {
 		.o-footer-services__icon-link {
 			@include oTypographySans($weight: 'semibold', $include-font-family: false);
-			@include oTypographyLink($theme: (
-				'base': _oFooterServicesGet('link-color'),
-				'hover': _oFooterServicesGet('link-hover-color'),
-				'context': _oFooterServicesGet('background-color')
-			));
+			@include oTypographyLink();
 			// Remove link underline.
 			border-bottom: 0;
 			@supports (text-decoration-thickness: 0.25ex) {
 				text-decoration-line: none;
 			}
 
+			position: relative;
 			display: inline-block;
 			min-width: max-content;
 			margin: 0 1em 1.5em 0;
-		}
+			padding-left: $_o-footer-services-icon-size - 5;
 
-		// Output a footer class for each requested icon.
-		@each $icon in $icons {
-			// Allowed social images: https://registry.origami.ft.com/components/social-images
-			$allowed-social-images: (facebook, github, linkedin, pinterest, slack, tumblr, twitter, whatsapp, youtube);
-			// Error if one of the requested icons are not an Origami social share image.
-			@if(index($allowed-social-images, unquote($icon)) == null) {
-				@error '"#{$icon}" is not an Origami supported social image, please contact that Origami team if you would like support for this icon to be added. Available icons are currently: #{$allowed-social-images}';
+			&:before {
+				display: inline-block;
+				background-repeat: no-repeat;
+				background-size: contain;
+				background-position: 50%;
+				position: absolute;
+				content: '';
+				height: $_o-footer-services-icon-size;
+				width: $_o-footer-services-icon-size;
+				vertical-align: middle;
+				top: -5px;
+				left: -5px;
 			}
-			// Output icon class e.g. `.o-footer-services__icon-link--slack`
-			.o-footer-services__icon-link--#{$icon} {
-				@include _oFooterServicesIcons($icon);
-			}
+		}
+	}
+
+	@if(index($themes, 'dark') and _oFooterServicesSupports('dark')) {
+		.o-footer-services--dark {
+			@include _oFooterServicesTheme($theme-name: 'dark', $icons: $icons);
 		}
 	}
 }

--- a/origami.json
+++ b/origami.json
@@ -68,7 +68,17 @@
 			"title": "Footer",
 			"name": "footer",
 			"template": "demos/src/footer.mustache",
-			"description": "The full internal product and tooling footer"
+			"description": "The full services footer"
+		},
+		{
+			"title": "Dark Theme",
+			"name": "dark-footer",
+			"template": "demos/src/footer.mustache",
+			"data": {
+				"theme": "dark"
+			},
+			"brands": ["master"],
+			"description": "A dark theme, shown on the full services footer."
 		}
 	]
 }

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -38,8 +38,19 @@ $_o-footer-services-shared-brand-config: (
 
 @if oBrandGetCurrentBrand() == 'master' {
 	@include oBrandDefine('o-footer-services', 'master', (
-		'variables': $_o-footer-services-shared-brand-config,
-		'supports-variants': ()
+		'variables': map-merge($_o-footer-services-shared-brand-config, (
+			'dark': (
+				text-color: oColorsByName('white'),
+				background-color: oColorsByName('slate'),
+				border-color: oColorsMix('white', 'slate', 20),
+				link-color: oColorsByName('white'),
+				link-hover-color: oColorsByName('white'),
+				legal-text-color: oColorsMix('white', 'slate', 60)
+			)
+		)),
+		'supports-variants': (
+			'dark'
+		)
 	));
 }
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,9 +1,5 @@
 @mixin _oFooterServicesBase() {
-	.o-footer-services {
-		@include oTypographySans(0);
-		color: _oFooterServicesGet('text-color');
-		background: _oFooterServicesGet('background-color');
-	}
+	@include oTypographySans(0);
 
 	.o-footer-services__container {
 		width: 100%;
@@ -12,7 +8,8 @@
 		&:before {
 			content: '';
 			position: absolute;
-			border-top: 1px solid _oFooterServicesGet('border-color');
+			border-top-width: 1px;
+			border-top-style: solid;
 			top: 0;
 			left: 0;
 			right: 0;
@@ -34,7 +31,6 @@
 
 		&--legal {
 			@include oTypographySans($scale: -1, $line-height: 20px);
-			color: _oFooterServicesGet('legal-text-color');
 			overflow: hidden;
 
 			p {
@@ -48,42 +44,22 @@
 		}
 	}
 
+	.o-footer-services__links a,
+	.o-footer-services__content a {
+		@include oTypographyLink();
+	}
+
 	.o-footer-services__links {
 		float: left;
 		margin: 0.5em 0;
 
 		a {
-			@include oTypographyLink($theme: (
-				'base': _oFooterServicesGet('legal-text-color'),
-				'hover': _oFooterServicesGet('legal-text-color'),
-				'context': _oFooterServicesGet('background-color')
-			));
 			margin-right: 0.5em;
 		}
 	}
 
 	.o-footer-services__content {
 		margin: 0 0 1.5em;
-
-		a {
-			@include oTypographyLink($theme: (
-				'base': _oFooterServicesGet('link-color'),
-				'hover': _oFooterServicesGet('link-hover-color'),
-				'context': _oFooterServicesGet('background-color')
-			));
-		}
-
-		.o-footer-services__content--external {
-			@include oTypographyLink(
-				$theme: (
-					'base': _oFooterServicesGet('link-color'),
-					'hover': _oFooterServicesGet('link-color'),
-					'context': _oFooterServicesGet('background-color')
-				),
-				$external: true,
-				$include-base-styles: false
-			);
-		}
 	}
 }
 
@@ -102,48 +78,94 @@
 		$url-encoded-logo: $url-encoded-logo + if($character == ':', '%3A', $character);
 	}
 
-	.o-footer-services__logo {
-		@include oTypographySans(1, $weight: 'semibold');
-		min-width: max-content;
-		min-height: 1em; //holds the logo in place if there is no text
-		margin: 0 1.5em 1.5em 0;
+	@include oTypographySans(1, $weight: 'semibold');
+	min-width: max-content;
+	min-height: 1em; //holds the logo in place if there is no text
+	margin: 0 1.5em 1.5em 0;
 
-		position: relative;
-		padding-left: calc(#{$_o-footer-services-logo-size} + 0.5em);
-
-		&:before {
-			display: inline-block;
-			background-repeat: no-repeat;
-			background-size: contain;
-			background-position: 50%;
-			vertical-align: baseline;
-			background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/#{$url-encoded-logo}?source=#{$system-code}');
-			content: '';
-			width: $_o-footer-services-logo-size;
-			height: $_o-footer-services-logo-size;
-			position: absolute;
-			top: -50%;
-			left: 0;
-		}
-	}
-}
-
-@mixin _oFooterServicesIcons($icon-name) {
 	position: relative;
-	padding-left: $_o-footer-services-icon-size - 5;
+	padding-left: calc(#{$_o-footer-services-logo-size} + 0.5em);
 
 	&:before {
 		display: inline-block;
 		background-repeat: no-repeat;
 		background-size: contain;
 		background-position: 50%;
-		position: absolute;
+		vertical-align: baseline;
+		background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/#{$url-encoded-logo}?source=#{$system-code}');
 		content: '';
-		background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/ftsocial-v2%3A#{$icon-name}?source=#{$system-code}&format=svg');
-		height: $_o-footer-services-icon-size;
-		width: $_o-footer-services-icon-size;
-		vertical-align: middle;
-		top: -5px;
-		left: -5px;
+		width: $_o-footer-services-logo-size;
+		height: $_o-footer-services-logo-size;
+		position: absolute;
+		top: -50%;
+		left: 0;
+	}
+}
+
+@mixin _oFooterServicesTheme($theme-name, $icons) {
+	color: _oFooterServicesGet('text-color', $from: $theme-name);
+	background: _oFooterServicesGet('background-color', $from: $theme-name);
+
+	.o-footer-services__container:before {
+		border-color: _oFooterServicesGet('border-color', $from: $theme-name);
+	}
+
+	.o-footer-services__wrapper--legal {
+		color: _oFooterServicesGet('legal-text-color', $from: $theme-name);
+	}
+
+	.o-footer-services__links a {
+		@include oTypographyLink($theme: (
+			'base': _oFooterServicesGet('legal-text-color', $from: $theme-name),
+			'hover': _oFooterServicesGet('legal-text-color', $from: $theme-name),
+			'context': _oFooterServicesGet('background-color', $from: $theme-name)
+		), $include-base-styles: false);
+	}
+
+	.o-footer-services__content {
+		a {
+			@include oTypographyLink($theme: (
+				'base': _oFooterServicesGet('link-color', $from: $theme-name),
+				'hover': _oFooterServicesGet('link-hover-color', $from: $theme-name),
+				'context': _oFooterServicesGet('background-color', $from: $theme-name)
+			), $include-base-styles: false);
+		}
+
+		.o-footer-services__content--external {
+			@include oTypographyLink(
+				$theme: (
+					'base': _oFooterServicesGet('link-color', $from: $theme-name),
+					'hover': _oFooterServicesGet('link-color', $from: $theme-name),
+					'context': _oFooterServicesGet('background-color', $from: $theme-name)
+				),
+				$external: true,
+				$include-base-styles: false
+			);
+		}
+	}
+
+	// Output a footer class for each requested icon.
+	@if $icons {
+		.o-footer-services__icon-link {
+			@include oTypographyLink($theme: (
+				'base': _oFooterServicesGet('text-color', $from: $theme-name),
+				'hover': _oFooterServicesGet('link-hover-color', $from: $theme-name),
+				'context': _oFooterServicesGet('background-color', $from: $theme-name)
+			), $include-base-styles: false);
+		}
+
+		@each $icon in $icons {
+			// Allowed social images: https://registry.origami.ft.com/components/social-images
+			$allowed-social-images: (facebook, github, linkedin, pinterest, slack, tumblr, twitter, whatsapp, youtube);
+			// Error if one of the requested icons are not an Origami social share image.
+			@if(index($allowed-social-images, unquote($icon)) == null) {
+				@error '"#{$icon}" is not an Origami supported social image, please contact that Origami team if you would like support for this icon to be added. Available icons are currently: #{$allowed-social-images}';
+			}
+			// Output icon class e.g. `.o-footer-services__icon-link--slack`
+			.o-footer-services__icon-link--#{$icon}:before {
+				$text-color-encoded: str-slice(ie-hex-str(_oFooterServicesGet('text-color', $from: $theme-name)), 4);
+				background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/ftsocial-v2%3A#{$icon}?source=#{$system-code}&tint=#{$text-color-encoded}&format=svg');
+			}
+		}
 	}
 }

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -6,7 +6,7 @@
 			}
 			// o-footer-service__container base styles
 			@include contains($selector: false) {
-				.o-footer-services__container {
+				.o-footer-services .o-footer-services__container {
 					width: 100%;
 					position: relative;
 				}
@@ -18,8 +18,8 @@
 			}
 			// o-footer-services__icon-link--github icon styles
 			@include contains($selector: false) {
-				.o-footer-services__icon-link--github:before {
-					background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/ftsocial-v2%3Agithub?source=#{$system-code}&format=svg");
+				.o-footer-services .o-footer-services__icon-link--github:before {
+					background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/ftsocial-v2%3Agithub?source=#{$system-code}&tint=000000&format=svg");
 				}
 			}
 		}
@@ -46,8 +46,8 @@
 			}
 			// o-footer-service__container base styles
 			@include contains($selector: false) {
-				.o-footer-services__icon-link--whatsapp:before {
-					background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/ftsocial-v2%3Awhatsapp?source=#{$system-code}&format=svg");
+				.o-footer-services .o-footer-services__icon-link--whatsapp:before {
+					background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/ftsocial-v2%3Awhatsapp?source=#{$system-code}&tint=000000&format=svg");
 				}
 			}
 		}


### PR DESCRIPTION
Inspired by the existing o-footer dark theme:
https://github.com/Financial-Times/o-footer/tree/v7.0.10#themes

To be used in new products which are distinct from ft.com, and
therefore can not use o-footer:
https://financialtimes.slack.com/archives/C01481FKWA2/p1594978425069100

<img width="1433" alt="Screenshot 2020-07-20 at 12 38 40" src="https://user-images.githubusercontent.com/10405691/87937240-3e704a00-ca8c-11ea-96f1-c8927454f5b5.png">
