### PR TITLE
Add "a Nikkei company" brand strip.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,12 @@ E.g. to output styles for the dark theme with a project logo, but without the de
 ```
 All options include:
 
-| Option    | Description                                                                                                                                         | Brand support                |
-|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|
-| logo      | A logo from the [image service](https://github.com/Financial-Times/origami-image-service.) to include in the footer (e.g. `ftlogo-v1:origami`).     | master, internal, whitelabel |
-| icons     | A list of [social share](https://registry.origami.ft.com/components/social-images) icons to include links for, defaults to '('slack', 'github')`.         | master, internal, whitelabel |
-| themes    | A list of themes to include. Currently the only theme is `dark`, which is only supported by the master brand.         | master |
+| Option      | Description                                                                                                                                               | Brand support                |
+|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|
+| logo        | A logo from the [image service](https://github.com/Financial-Times/origami-image-service.) to include in the footer (e.g. `ftlogo-v1:origami`).           | master, internal, whitelabel |
+| icons       | A list of [social share](https://registry.origami.ft.com/components/social-images) icons to include links for, defaults to '('slack', 'github')`.         | master, internal, whitelabel |
+| brand-strip | Whether to include styles for the brand strip at the bottom of the footer, "a Nikkei company".                                                            | master, internal, whitelabel |
+| themes      | A list of themes to include. Currently the only theme is `dark`, which is only supported by the master brand.                                             | master                       |
 
 
 Your project should call `oFooterServices` once, and add to the `opts` argument when new features are needed. However, if `oFooterServices` is called multiple times, for example for code splitting across multiple bundles, the `$include-base-styles` argument may be set to `false` to omit fundamental base styles required by all options.
@@ -113,7 +114,9 @@ $o-brand: whitelabel;
 	'border-color': hotpink,
 	'link-color': rgb(156, 4, 85),
 	'link-hover-color': rgb(156, 4, 85),
-	'legal-text-color': rgb(214, 73, 148)
+	'legal-text-color': rgb(214, 73, 148),
+	'brand-background-color': oColorsByName('black'),
+	'brand-foreground-color': oColorsByName('white'),
 ));
 
 // Output o-footer-services css
@@ -130,6 +133,8 @@ Available brand variables include:
 - `link-color`: The default link colour.
 - `link-hover-color`: The hover colour of links with no underline, i.e. icon links.
 - `legal-text-color`: The colour of legal links.
+- `brand-background-color`: The background colour of the brand strip, at the bottom of the footer, "a Nikkei company".
+- `brand-foreground-color`: The foreground colour for the logo in the brand strip, at the bottom of the footer, "a Nikkei company".
 
 
 ## Migration guide

--- a/demos/src/brand-strip.mustache
+++ b/demos/src/brand-strip.mustache
@@ -1,0 +1,10 @@
+<div class="demo">
+	<footer class="o-footer-services">
+		<div class="o-footer-services__container o-footer-services__container--brand">
+		    <div class="o-footer-services__wrapper">
+			    <div class="o-footer-services__brand-logo">
+			    </div>
+		    </div>
+		</div>
+	</footer>
+</div>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -11,5 +11,6 @@ body {
 @include oFooterServices($opts: (
 	'logo': 'ftlogo-v1:origami',
 	'icons': ('slack', 'github'),
+	'brand-strip': true,
 	'themes': ('dark')
 ));

--- a/demos/src/footer.mustache
+++ b/demos/src/footer.mustache
@@ -18,5 +18,11 @@
 			</div>
 			<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 		</div>
+		<div class="o-footer-services__container o-footer-services__container--brand">
+		    <div class="o-footer-services__wrapper">
+			    <div class="o-footer-services__brand-logo">
+			    </div>
+		    </div>
+		</div>
 	</footer>
 </div>

--- a/main.scss
+++ b/main.scss
@@ -9,17 +9,19 @@
 @import 'src/scss/variables';
 
 /// Outputs all features and styles available for o-footer-services.
-/// @param {map} $opts [('logo': 'ftlogo-v1:origami', 'icons': ('slack', 'github'))] - A map of optional footer features to output, including the footer logo and list of social icon links.
+/// @param {map} $opts [('logo': 'ftlogo-v1:origami', 'icons': ('slack', 'github'), 'brand-strip': true)] - A map of optional footer features to output, including the footer logo, list of social icon links, and "a Nikkei company" brand strip.
 /// @param {bool} $include-base-styles [true] - Whether to output fundamental o-footer-services styles required by the optional features.
 /// @access public
 @mixin oFooterServices($opts: (
 	'logo': false,
 	'icons': ('slack', 'github'),
+	'brand-strip': true,
 	'themes': ('dark')
 ), $include-base-styles: true) {
 	$logo: map-get($opts, 'logo');
 	$icons: map-get($opts, 'icons');
 	$themes: map-get($opts, 'themes');
+	$include-brand-strip: map-get($opts, 'brand-strip');
 
 	// Error if the global $system-code variable is not set.
 	// This is required for image service requests.
@@ -32,7 +34,24 @@
 		.o-footer-services {
 			@include _oFooterServicesBase();
 			// include default theme with base styles
-			@include _oFooterServicesTheme($theme-name: null, $icons: $icons);
+			@include _oFooterServicesTheme($theme-name: null, $icons: $icons, $brand-strip: $include-brand-strip);
+		}
+	}
+
+	// Include structural styles for the brand strip,
+	// background and logo colours are applied by the theme.
+	@if($include-brand-strip) {
+		.o-footer-services__container--brand {
+			&:before {
+				content: initial;
+			}
+		}
+
+		.o-footer-services__brand-logo {
+			height: 1.25em;
+			padding: oSpacingByName('s2');
+			background-repeat: no-repeat;
+			background-position: right;
 		}
 	}
 
@@ -78,7 +97,7 @@
 
 	@if(index($themes, 'dark') and _oFooterServicesSupports('dark')) {
 		.o-footer-services--dark {
-			@include _oFooterServicesTheme($theme-name: 'dark', $icons: $icons);
+			@include _oFooterServicesTheme($theme-name: 'dark', $icons: $icons, $brand-strip: $include-brand-strip);
 		}
 	}
 }

--- a/origami.json
+++ b/origami.json
@@ -62,6 +62,12 @@
 			"description": "Minimal footer without content"
 		},
 		{
+			"title": "Brand Strip",
+			"name": "brand-strip",
+			"template": "demos/src/brand-strip.mustache",
+			"description": "A brand strip may optionally be included."
+		},
+		{
 			"title": "Footer",
 			"name": "footer",
 			"template": "demos/src/footer.mustache",

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -21,7 +21,9 @@
 ///     	'border-color': hotpink,
 ///     	'link-color': rgb(156, 4, 85),
 ///     	'link-hover-color': rgb(156, 4, 85),
-///     	'legal-text-color': rgb(214, 73, 148)
+///     	'legal-text-color': rgb(214, 73, 148),
+///     	'brand-background-color': oColorsByName('black'),
+///     	'brand-foreground-color': oColorsByName('white'),
 ///     ));
 @mixin oFooterServicesCustomize($variables) {
 	@include oBrandCustomize('o-footer-services', $variables);
@@ -33,19 +35,22 @@ $_o-footer-services-shared-brand-config: (
 	border-color: oColorsByName('black-20'),
 	link-color: oColorsByName('black-80'),
 	link-hover-color: oColorsByName('black-60'),
-	legal-text-color: oColorsByName('black-60')
+	legal-text-color: oColorsByName('black-60'),
+	brand-background-color: oColorsByName('black'),
 );
 
 @if oBrandGetCurrentBrand() == 'master' {
 	@include oBrandDefine('o-footer-services', 'master', (
 		'variables': map-merge($_o-footer-services-shared-brand-config, (
+			brand-background-color: oColorsByName('black-20'),
 			'dark': (
 				text-color: oColorsByName('white'),
 				background-color: oColorsByName('slate'),
 				border-color: oColorsMix('white', 'slate', 20),
 				link-color: oColorsByName('white'),
 				link-hover-color: oColorsByName('white'),
-				legal-text-color: oColorsMix('white', 'slate', 60)
+				legal-text-color: oColorsMix('white', 'slate', 60),
+				brand-background-color: oColorsByName('black')
 			)
 		)),
 		'supports-variants': (
@@ -59,6 +64,7 @@ $_o-footer-services-shared-brand-config: (
 		'variables': map-merge($_o-footer-services-shared-brand-config, (
 			'background-color': oColorsByName('slate-white-5'),
 			'border-color': oColorsByName('slate-white-15'),
+			'brand-background-color': oColorsByName('slate')
 		)),
 		'supports-variants': ()
 	));

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -102,7 +102,7 @@
 	}
 }
 
-@mixin _oFooterServicesTheme($theme-name, $icons) {
+@mixin _oFooterServicesTheme($theme-name, $icons, $brand-strip) {
 	color: _oFooterServicesGet('text-color', $from: $theme-name);
 	background: _oFooterServicesGet('background-color', $from: $theme-name);
 
@@ -144,6 +144,20 @@
 		}
 	}
 
+	@if $brand-strip {
+		.o-footer-services__container--brand {
+			$brand-background: _oFooterServicesGet('brand-background-color', $theme-name);
+			$default-background: _oFooterServicesGet('background-color', $theme-name);
+			background: if($brand-background, $brand-background, $default-background);
+		}
+
+		.o-footer-services__brand-logo {
+			$logo-color: _oFooterServicesGet('brand-foreground-color', $theme-name);
+			@include _oFooterServicesBrandImage('brand-nikkei-tagline', 200, $logo-color);
+		}
+	}
+
+
 	// Output a footer class for each requested icon.
 	@if $icons {
 		.o-footer-services__icon-link {
@@ -168,4 +182,27 @@
 			}
 		}
 	}
+}
+
+/// Construct a logo image URL
+///
+/// @param {String} $logo-name
+/// @param {Number} $fallback-width
+/// @param {String|Null} $color [null]
+@mixin _oFooterServicesBrandImage($logo-name, $fallback-width, $color: null) {
+	// Error if the global $system-code variable is not set.
+	// This is required for image service requests.
+	@if(global-variable-exists('system-code') == false or type-of($system-code) != 'string') {
+		@error 'A global "$system-code" Sass variable must be set to a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems).';
+	}
+
+	$url-encoded-color: if($color, '%23#{str-slice(ie-hex-str($color), 4)}', null);
+	$base-url: 'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:';
+	$url:
+		$base-url +
+		$logo-name +
+		'?source=#{$system-code}' +
+		if($url-encoded-color, '&tint=#{$url-encoded-color}', '')
+		+ '&format=svg';
+	background-image: url($url);
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -190,12 +190,6 @@
 /// @param {Number} $fallback-width
 /// @param {String|Null} $color [null]
 @mixin _oFooterServicesBrandImage($logo-name, $fallback-width, $color: null) {
-	// Error if the global $system-code variable is not set.
-	// This is required for image service requests.
-	@if(global-variable-exists('system-code') == false or type-of($system-code) != 'string') {
-		@error 'A global "$system-code" Sass variable must be set to a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems).';
-	}
-
 	$url-encoded-color: if($color, '%23#{str-slice(ie-hex-str($color), 4)}', null);
 	$base-url: 'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:';
 	$url:


### PR DESCRIPTION
This brings the "a Nikkei company" brand strip to o-footer-services
from o-footer. The first project to use this will be the new
"about us" ft.com page.

master brand: default
![Screenshot 2021-01-27 at 11 47 43](https://user-images.githubusercontent.com/10405691/105987168-ccf60180-6095-11eb-83d4-fc069141d4a4.png)
master brand: dark theme
![Screenshot 2021-01-27 at 11 47 47](https://user-images.githubusercontent.com/10405691/105987186-d5e6d300-6095-11eb-8512-4a8494b537ed.png)

internal brand: default
![Screenshot 2021-01-27 at 11 48 01](https://user-images.githubusercontent.com/10405691/105987201-dd0de100-6095-11eb-9951-1b3596b86ed5.png)

whitelabel brand: default
![Screenshot 2021-01-27 at 11 48 14](https://user-images.githubusercontent.com/10405691/105987221-e5661c00-6095-11eb-8062-3ea1499ad78d.png)
